### PR TITLE
No uppercase text transform for API headers

### DIFF
--- a/source/stylesheets/api.css.scss
+++ b/source/stylesheets/api.css.scss
@@ -5,3 +5,6 @@
     text-transform: uppercase;
   }
 }
+.api-header {
+  text-transform: none;
+}


### PR DESCRIPTION
Improves the readability of the API docs by removing the uppercase text transform. See #2276
